### PR TITLE
Add interactive tabbed collections section

### DIFF
--- a/aadaii-hay-theme/assets/theme.js
+++ b/aadaii-hay-theme/assets/theme.js
@@ -11,4 +11,15 @@ document.addEventListener('DOMContentLoaded', () => {
     show(0);
     setInterval(()=>{ i = (i+1) % all.length; show(i); }, interval);
   });
+
+  document.querySelectorAll('.tabs-section').forEach(section => {
+    const pills = section.querySelectorAll('.pill');
+    const panels = section.querySelectorAll('.tab-content');
+    function activate(idx){
+      pills.forEach((p,i)=> p.classList.toggle('is-active', i === idx));
+      panels.forEach((p,i)=> p.hidden = i !== idx);
+    }
+    pills.forEach((p,i)=> p.addEventListener('click', () => activate(i)));
+    if (pills.length) activate(0);
+  });
 });

--- a/aadaii-hay-theme/sections/tabbed-collections.liquid
+++ b/aadaii-hay-theme/sections/tabbed-collections.liquid
@@ -1,39 +1,51 @@
 {% comment %} Tabbed Collections Section {% endcomment %}
-<section id="tabbed-collections-{{ section.id }}">
-  <div class="tabs">
+<section id="tabbed-collections-{{ section.id }}" class="tabs-section">
+  {% if section.settings.heading != blank %}
+    <h2>{{ section.settings.heading }}</h2>
+  {% endif %}
+
+  <div class="pill-row">
     {% for i in (1..4) %}
       {% assign key = 'collection_' | append: i %}
       {% assign coll = section.settings[key] %}
       {% if coll %}
-        <button class="tab" data-target="tab-{{ i }}">{{ coll.title }}</button>
+        <button class="pill{% if forloop.first %} is-active{% endif %}" data-target="tab-{{ section.id }}-{{ i }}">{{ coll.title }}</button>
       {% endif %}
     {% endfor %}
   </div>
 
-  <div class="panels">
-    {% for i in (1..4) %}
-      {% assign key = 'collection_' | append: i %}
-      {% assign coll = section.settings[key] %}
-      {% if coll %}
-        <div id="tab-{{ i }}" class="panel">
-          <h3>{{ coll.title }}</h3>
-          <ul class="grid">
-            {% for product in coll.products limit: 4 %}
-              <li>
-                <a href="{{ product.url }}">{{ product.title }}</a>
-              </li>
-            {% endfor %}
-          </ul>
+  {% for i in (1..4) %}
+    {% assign key = 'collection_' | append: i %}
+    {% assign coll = section.settings[key] %}
+    {% if coll %}
+      <div id="tab-{{ section.id }}-{{ i }}" class="tab-content"{% unless forloop.first %} hidden{% endunless %}>
+        <div class="grid grid--2 grid--3-md grid--4-lg">
+          {% for product in coll.products limit: section.settings.limit %}
+            {% render 'card-product', product: product, aspect: section.settings.aspect %}
+          {% endfor %}
         </div>
-      {% endif %}
-    {% endfor %}
-  </div>
+      </div>
+    {% endif %}
+  {% endfor %}
 </section>
 
 {% schema %}
 {
   "name": "Tabbed collections",
   "settings": [
+    { "type": "text", "id": "heading", "label": "Heading", "default": "New Arrivals" },
+    { "type": "range", "id": "limit", "min": 2, "max": 12, "step": 1, "label": "Products to show", "default": 4 },
+    {
+      "type": "select",
+      "id": "aspect",
+      "label": "Image aspect",
+      "default": "square",
+      "options": [
+        { "value": "square", "label": "Square" },
+        { "value": "portrait", "label": "Portrait" },
+        { "value": "landscape", "label": "Landscape" }
+      ]
+    },
     { "type": "collection", "id": "collection_1", "label": "Collection 1" },
     { "type": "collection", "id": "collection_2", "label": "Collection 2" },
     { "type": "collection", "id": "collection_3", "label": "Collection 3" },


### PR DESCRIPTION
## Summary
- add pill-based tabbed collections section with configurable heading, product limit, and image aspect
- include JavaScript to switch tab panels client side

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e1b3e60c832aadedfa0f30fb6c85